### PR TITLE
Remove unused jsoup dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,11 +38,6 @@
             <version>2.12.1</version>
         </dependency>
         <dependency>
-            <groupId>org.jsoup</groupId>
-            <artifactId>jsoup</artifactId>
-            <version>1.14.2</version>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.1</version>


### PR DESCRIPTION
# What's new in this PR?

### Issues

3rd party dependencies can contain security bugs from time to time, removing unused dependencies from `pom.xml` reduces noise on the automated alerts informing about potential vulnerable versions

### Solutions

jsoup is not used in this project and can therefore be removed here

this closes #5 (makes it obsolete)